### PR TITLE
買いルールFix

### DIFF
--- a/Strider/MachineLearning_RandomForest.py
+++ b/Strider/MachineLearning_RandomForest.py
@@ -11,33 +11,60 @@ from sklearn.metrics import classification_report
 from u_def import JockeyTable as jtbl   # 騎手名→勝率変換用関数
 
 
-# 学習&教師用ファクターリスト
-factor_list01 = [
-                  "合計値順位",   #グループ1
-                 
-                  "仕上指数順位", #グループ2
-                  "ＳＴ指数順位", #グループ2
-                 
-                  "合計値",       #グループ3
-                  "展開順位",     #グループ3
-                
-                  "展開ゴール差", #グループ4
-                  "瞬発力順位",   #グループ4
-                  "ＳＴ指数",     #グループ4
-                  "仕上指数",     #グループ4
-                  
-                  "持続力順位",   #グループ5
-                  "瞬発力",       #グループ5
-                  "騎手名",       #グループ5
-                  "先行力順位",   #グループ5
-                  "持久力",       #グループ5
-                  "先行力",       #グループ5
-                  "追走力",       #グループ5
-                  "持続力",       #グループ5
-                  "持久力順位",   #グループ5
-                  "追走力順位"    #グループ5
-                ]
+# 事前/直前ファクター切替 (0：事前, 1：直前)
+sw_Tyokuten = 1
 
+if sw_Tyokuten == 0:
+
+    # 学習&教師用ファクターリスト
+    factor_list01 = [
+    #                 "合計値順位",   #グループ1    # 該当ファクターは影響力強すぎの為、コメントアウト
+                     
+                      "仕上指数順位", #グループ2
+                      "ＳＴ指数順位", #グループ2
+                     
+                      "合計値",       #グループ3
+                      "展開順位",     #グループ3
+                    
+                      "展開ゴール差", #グループ4
+                      "瞬発力順位",   #グループ4
+                      "ＳＴ指数",     #グループ4
+                      "仕上指数",     #グループ4
+                      
+                      "持続力順位",   #グループ5
+                      "瞬発力",       #グループ5
+                      "騎手名",       #グループ5
+                      "先行力順位",   #グループ5
+                      "持久力",       #グループ5
+                      "先行力",       #グループ5
+                      "追走力",       #グループ5
+                      "持続力",       #グループ5
+                      "持久力順位",   #グループ5
+                      "追走力順位"    #グループ5
+                    ]
+else:
+    factor_list01 = [
+                      "直前印",
+                      "前日印",
+                      "指数印",
+                      "激走馬",
+                      "脚質(前走)",
+                      "パドック",
+                      "オッズ",
+                      "馬体",
+                      "気配",
+                      "状態",
+                      "脚元",
+                      "馬具",
+                      "馬場",
+                      "脚質",
+                      "合算値",
+                      "ゴール前着差",
+                      "上昇馬"
+                    ]
+
+
+print("データ準備中...")
 # 学習用CSV名設定
 l_DataName = "00_LearnData.csv"
 # 予想用CSV名設定
@@ -57,22 +84,56 @@ learn_DataFrame = learn_DataFrame[ learn_DataFrame["着"] != "取消" ]         
 # 学習データ取得
 data_x = learn_DataFrame[ factor_list01 ]
 data_x = jtbl.JockeyTable(data_x)            # 騎手名 → 勝率変換
+data_x = data_x.astype('float64')            # データフレーム全体を浮動小数点型でキャスト
 
 # 教師データ取得
 data_y = learn_DataFrame[ "着" ]
+data_y = data_y.astype('float64')            # データフレーム全体を浮動小数点型でキャスト
 
 
-# 森の深さ設定
+# 森の深さ設定 (設定なしの場合最大深度まで実施)
 depth_set = 15
+
 # 森の数設定
 n_estimators_set = 100
 
 # ランダムフォレスト準備
 rf1 = RandomForestRegressor( n_estimators = n_estimators_set, max_depth = depth_set )
 
-print(data_x.head())
-print(data_y.head())
+print("学習1回目")
+########################################################################################
+# 学習1回目
+########################################################################################
+# ランダムフォレスト学習
+rf1.fit( data_x, data_y )
 
+# ランダムフォレスト予想
+test_X = test_DataFrame[ factor_list01 ]
+test_X = jtbl.JockeyTable(test_X)            # 騎手名 → 勝率変換
+result1 = rf1.predict( test_X )
+# CSVファイルへ結果出力
+test_DataFrame['R予想1'] = result1
+
+
+print("学習2回目")
+########################################################################################
+# 学習2回目
+########################################################################################
+# ランダムフォレスト学習
+rf1.fit( data_x, data_y )
+
+# ランダムフォレスト予想
+test_X = test_DataFrame[ factor_list01 ]
+test_X = jtbl.JockeyTable(test_X)            # 騎手名 → 勝率変換
+result1 = rf1.predict( test_X )
+# CSVファイルへ結果出力
+test_DataFrame['R予想2'] = result1
+
+
+print("学習3回目")
+########################################################################################
+# 学習3回目
+########################################################################################
 # ランダムフォレスト学習
 rf1.fit( data_x, data_y )
 
@@ -81,11 +142,83 @@ test_X = test_DataFrame[ factor_list01 ]
 test_X = jtbl.JockeyTable(test_X)            # 騎手名 → 勝率変換
 result1 = rf1.predict( test_X )
 
-print('check:',result1)
+# CSVファイルへ結果出力
+test_DataFrame['R予想3'] = result1
+
+
+print("学習4回目")
+########################################################################################
+# 学習4回目
+########################################################################################
+# ランダムフォレスト学習
+rf1.fit( data_x, data_y )
+
+# ランダムフォレスト予想
+test_X = test_DataFrame[ factor_list01 ]
+test_X = jtbl.JockeyTable(test_X)            # 騎手名 → 勝率変換
+result1 = rf1.predict( test_X )
 
 # CSVファイルへ結果出力
-test_DataFrame['R予想'] = result1
-test_DataFrame.to_csv("01_rslt_rnd.csv", encoding="shift_jis", index=False, mode="a")
+test_DataFrame['R予想4'] = result1
+
+
+print("学習5回目")
+########################################################################################
+# 学習5回目
+########################################################################################
+# ランダムフォレスト学習
+rf1.fit( data_x, data_y )
+
+# ランダムフォレスト予想
+test_X = test_DataFrame[ factor_list01 ]
+test_X = jtbl.JockeyTable(test_X)            # 騎手名 → 勝率変換
+result1 = rf1.predict( test_X )
+
+# CSVファイルへ結果出力
+test_DataFrame['R予想5'] = result1
+
+
+
+# 評価補助用マスク処理
+# ◎は1に、〇は2に、△は3に、それ以下は4に置換
+# test_DataFrame['単勝(Mask)']   = test_DataFrame.apply( lambda x: 2 if float( x['単勝'] ) < 2
+#                                                             else 1 if float( x['単勝'] ) <= 5
+#                                                             else 3 if float( x['単勝'] ) <= 10
+#                                                             else 4, axis=1 )
+test_DataFrame['R予想1(Mask)'] = test_DataFrame.apply( lambda x: 1 if float( x['R予想1'] ) < 3
+                                                            else 2 if float( x['R予想1'] ) < 4
+                                                            else 3 if float( x['R予想1'] ) < 5
+                                                            else 4, axis=1 )
+test_DataFrame['R予想2(Mask)'] = test_DataFrame.apply( lambda x: 1 if float( x['R予想2'] ) < 3
+                                                            else 2 if float( x['R予想2'] ) < 4
+                                                            else 3 if float( x['R予想2'] ) < 5
+                                                            else 4, axis=1 )
+test_DataFrame['R予想3(Mask)'] = test_DataFrame.apply( lambda x: 1 if float( x['R予想3'] ) < 3
+                                                            else 2 if float( x['R予想3'] ) < 4
+                                                            else 3 if float( x['R予想3'] ) < 5
+                                                            else 4, axis=1 )
+test_DataFrame['R予想4(Mask)'] = test_DataFrame.apply( lambda x: 1 if float( x['R予想4'] ) < 3
+                                                            else 2 if float( x['R予想4'] ) < 4
+                                                            else 3 if float( x['R予想4'] ) < 5
+                                                            else 4, axis=1 )
+test_DataFrame['R予想5(Mask)'] = test_DataFrame.apply( lambda x: 1 if float( x['R予想5'] ) < 3
+                                                            else 2 if float( x['R予想5'] ) < 4
+                                                            else 3 if float( x['R予想5'] ) < 5
+                                                            else 4, axis=1 )
+
+
+print("CSV出力")
+print("*****************************************************************************")
+########################################################################################
+# CSV出力
+########################################################################################
+if sw_Tyokuten == 0:
+    test_DataFrame.to_csv("01_rslt_rnd_Pre.csv", encoding="shift_jis", index=False, mode="a")
+else:
+    test_DataFrame.to_csv("01_rslt_rnd_Now.csv", encoding="shift_jis", index=False, mode="a")
+
+
+# print('check:',result1)
 
 
 ########################################


### PR DESCRIPTION
<変更点>
・直前ファクター対応
・事前ファクターから合計値順位削除
  → 影響力強すぎで回収率のバラつき大の為
<買いルール>
・R予想1～5(Mask)が全て1であること
・購入時オッズが2～5倍の範囲であること
回収率：110%～125%
的中率：約36%前後
出現率(事前)：土日で3件程度(3会場時)
出現率(直前)：土日で8件程度(3会場時)